### PR TITLE
Cast objects to HttpContent in request body

### DIFF
--- a/src/IGateway.cs
+++ b/src/IGateway.cs
@@ -1,6 +1,5 @@
 using System.Net.Http;
 using System.Threading.Tasks;
-using StockportGovUK.NetStandard.Gateways.Response;
 
 namespace StockportGovUK.NetStandard.Gateways
 {
@@ -11,8 +10,6 @@ namespace StockportGovUK.NetStandard.Gateways
         Task<HttpResponseMessage> PatchAsync(object content);
         Task<HttpResponseMessage> PatchAsync(string url, object content);
         Task<HttpResponseMessage> PatchAsync(string url, object content, bool encodeContent);
-        Task<HttpResponse<T>> PatchAsync<T>(string url, object content);
-        Task<HttpResponse<T>> PatchAsync<T>(string url, object content, bool encodeContent);
         Task<HttpResponseMessage> PostAsync(string url, object content);
         Task<HttpResponseMessage> PostAsync(string url, object content, bool encodeContent);
         Task<HttpResponseMessage> DeleteAsync(string url);

--- a/src/ITypedGateway.cs
+++ b/src/ITypedGateway.cs
@@ -6,21 +6,13 @@ namespace StockportGovUK.NetStandard.Gateways
     interface ITypedGateway
     {
         Task<HttpResponse<T>> GetAsync<T>(string url);
-
         Task<HttpResponse<T>> PatchAsync<T>(string url, object content);
-
         Task<HttpResponse<T>> PatchAsync<T>(string url, object content, bool encodeContent);
-
         Task<HttpResponse<T>> PostAsync<T>(string url, object content);
-
         Task<HttpResponse<T>> PostAsync<T>(string url, object content, bool encodeContent);
-
         Task<HttpResponse<T>> PutAsync<T>(string url, object content);
-
         Task<HttpResponse<T>> PutAsync<T>(string url, object content, bool encodeContent);
-
         Task<HttpResponse<T>> DeleteAsync<T>(string url);
-
         void ChangeAuthenticationHeader(string authHeader);
     }
 }

--- a/src/StockportGovUK.NetStandard.Gateways.csproj
+++ b/src/StockportGovUK.NetStandard.Gateways.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Title>A package that provides base gateways using HttpClient</Title>
-    <VersionPrefix>3.0.4</VersionPrefix>
+    <VersionPrefix>3.0.5</VersionPrefix>
     <Authors>Colin Lees, Jon Chiles, Jon Hadley</Authors>
     <Company>Stockport Council</Company>
   </PropertyGroup>


### PR DESCRIPTION
Change type for request body from StringContent/HttpContent to always be HttpContent.
Effected methods:
- PutAsync<T>(string url, object content, bool encodeContent)
- PostAsync(string url, object content, bool encodeContent)
- PostAsync<T>(string url, object content, bool encodeContent)
- PatchAsync(string url, object content, bool encodeContent)
- PatchAsync<T>(string url, object content, bool encodeContent)

GetStringContent() has been removed and GetHttpContent put in it's place.