### PR TITLE
feat(JSON): add case insensitive to GET/POST

### DIFF
--- a/src/Gateway.cs
+++ b/src/Gateway.cs
@@ -157,10 +157,15 @@ namespace StockportGovUK.NetStandard.Gateways
         }
 
         private static HttpContent GetHttpContent(object content)
-            => new StringContent(JsonSerializer.Serialize(content, new JsonSerializerOptions
+        {
+            var options = new JsonSerializerOptions
             {
                 WriteIndented = true,
+                PropertyNameCaseInsensitive = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            }), Encoding.UTF8, "application/json");
+            };
+
+            return new StringContent(JsonSerializer.Serialize(content, options), Encoding.UTF8, "application/json");
+        }
     }
 }

--- a/src/Response/HttpResponse.cs
+++ b/src/Response/HttpResponse.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace StockportGovUK.NetStandard.Gateways.Response
@@ -28,7 +29,14 @@ namespace StockportGovUK.NetStandard.Gateways.Response
             try
             {
                 var content = await responseMessage.Content.ReadAsStringAsync();
-                deserializedObject = JsonSerializer.Deserialize<T>(content);
+                var options = new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    PropertyNameCaseInsensitive = true,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                };
+
+                deserializedObject = JsonSerializer.Deserialize<T>(content, options);
             }
             catch (Exception)
             {


### PR DESCRIPTION
Some issues returning data from Verint, flagged up problems with the new package using System.Text.

Added options to the deserialisers to use case insensitivity, to the POST & GET requests.

Tested it locally and it works as it should. 