### PR TITLE
fix(Serialisation): revert back to NewtonSoft

### DIFF
--- a/src/Gateway.cs
+++ b/src/Gateway.cs
@@ -2,9 +2,10 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Polly.CircuitBreaker;
 using StockportGovUK.NetStandard.Gateways.Response;
 
@@ -160,14 +161,12 @@ namespace StockportGovUK.NetStandard.Gateways
 
         private static HttpContent GetHttpContent(object content)
         {
-            var options = new JsonSerializerOptions
+            var serialisedObject = JsonConvert.SerializeObject(content, Formatting.Indented, new JsonSerializerSettings
             {
-                WriteIndented = true,
-                PropertyNameCaseInsensitive = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            };
+                NullValueHandling = NullValueHandling.Ignore
+            });
 
-            return new StringContent(JsonSerializer.Serialize(content, options), Encoding.UTF8, "application/json");
+            return new StringContent(serialisedObject, Encoding.UTF8, "application/json");
         }
     }
 }

--- a/src/Response/HttpResponse.cs
+++ b/src/Response/HttpResponse.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace StockportGovUK.NetStandard.Gateways.Response
@@ -29,14 +28,7 @@ namespace StockportGovUK.NetStandard.Gateways.Response
             try
             {
                 var content = await responseMessage.Content.ReadAsStringAsync();
-                var options = new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    PropertyNameCaseInsensitive = true,
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-                };
-
-                deserializedObject = JsonSerializer.Deserialize<T>(content, options);
+                deserializedObject = JsonSerializer.Deserialize<T>(content);
             }
             catch (Exception)
             {


### PR DESCRIPTION
Lightest touch to revert the use of System Text back to NewtonSoft - just serialising the GET and POST requests. Will check it through on int and qa when I update Formbuilder to use this package.