### PR TITLE
feat(Logging): add inner ex to message

### DIFF
--- a/src/Gateway.cs
+++ b/src/Gateway.cs
@@ -155,7 +155,8 @@ namespace StockportGovUK.NetStandard.Gateways
             }
             catch (Exception ex)
             {
-                throw new BrokenCircuitException($"{GetType().Name} => {requestType}({Client.BaseAddress}{url}) - Circuit open", ex);
+                throw new BrokenCircuitException(
+                    $"{GetType().Name} => {requestType}({Client.BaseAddress}{url}) - request failed. InnerException.Mesage: {ex.Message} + {ex.InnerException}", ex);
             }
         }
 

--- a/src/StockportGovUK.NetStandard.Gateways.csproj
+++ b/src/StockportGovUK.NetStandard.Gateways.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Title>A package that provides base gateways using HttpClient</Title>
-    <VersionPrefix>11.4.2</VersionPrefix>
+    <VersionPrefix>11.4.3</VersionPrefix>
     <Authors>Colin Lees, Jon Chiles, Jon Hadley</Authors>
     <Company>Stockport Council</Company>
   </PropertyGroup>


### PR DESCRIPTION
Inner Exception getting lost within the HttpResponse, so explicitly added to exception message from Gateways package that is being logged. Slightly reworded, as this error still throws even without using Polly ( Circuit Breaker ).
Put it down as a bug fix, although if so i think I need to improve the other model ( HttpResponse ) to properly handle Inner Exceptions.